### PR TITLE
kind_map subject->Pnoise

### DIFF
--- a/hcp/io/file_mapping/file_mapping.py
+++ b/hcp/io/file_mapping/file_mapping.py
@@ -169,7 +169,7 @@ kind_map = {
     'task_story_math': 'StoryM',
     'rest': 'Restin',
     'noise_empty_room': 'Rnoise',
-    'noise_subject': 'subject',
+    'noise_subject': 'Pnoise',
     'meg_anatomy': 'anatomy',
     'freesurfer': 'freesurfer'
 }


### PR DESCRIPTION
Currently, looking for subject noise files can fail, e.g.:
`hcp.io.read_info_hcp(subject=subject, data_type='noise_subject')`

This is because the file mapping returns:
```
['100307/unprocessed/MEG/2-subject/4D/c,rfDC',
 '100307/unprocessed/MEG/2-subject/4D/config']
```

I think it should be `Pnoise` instead of `subject`?
