### PR TITLE
FIX: compute_forward_stack works with setup_source_space in mne-0.15dev

### DIFF
--- a/hcp/anatomy.py
+++ b/hcp/anatomy.py
@@ -207,11 +207,17 @@ def compute_forward_stack(subjects_dir,
     head_mri_t = mne.read_trans(
         op.join(recordings_path, subject, '{}-head_mri-trans.fif'.format(
             subject)))
-
-    src_params = _update_dict_defaults(
-        src_params,
-        dict(subject='fsaverage', spacing='oct6', n_jobs=n_jobs,
-             surface='white', subjects_dir=subjects_dir, add_dist=True))
+    
+    src_defaults = dict(subject='fsaverage', spacing='oct6', n_jobs=n_jobs,
+             surface='white', subjects_dir=subjects_dir, add_dist=True)
+    if 'fname' in mne.fixes._get_args(mne.setup_source_space):
+        # needed for mne-0.14 and below
+        src_defaults.update(dict(fname=None))
+    else:
+        # remove 'fname' argument (if necessary) when using mne-0.15+
+        if 'fname' in src_params:
+            del src_params['fname']
+    src_params = _update_dict_defaults(src_params, src_defaults)
 
     add_source_space_distances = False
     if src_params['add_dist']:  # we want the distances on the morphed space


### PR DESCRIPTION
mne-0.15dev removed the `fname` argument from `setup_source_space` and this makes `compute_forward_stack` work with both mne-0.14 and mne-0.15.