### PR TITLE
Preprocessing scikit-learn update

### DIFF
--- a/hcp/preprocessing.py
+++ b/hcp/preprocessing.py
@@ -91,13 +91,14 @@ def apply_ref_correction(raw, decim_fit=100):
         Defaults to 100.
     """
     from sklearn.linear_model import LinearRegression
-
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.pipeline import Pipeline
     meg_picks = mne.pick_types(raw.info, ref_meg=False, meg=True)
     ref_picks = mne.pick_types(raw.info, ref_meg=True, meg=False)
     if len(ref_picks) == 0:
         raise ValueError('Could not find meg ref channels.')
 
-    estimator = LinearRegression(normalize=True)  # ref MAG + GRAD
+    estimator = Pipeline([('scaler', StandardScaler()), ('estimator', LinearRegression())]) # ref MAG + GRAD
     Y_pred = estimator.fit(
         raw[ref_picks][0][:, ::decim_fit].T,
         raw[meg_picks][0][:, ::decim_fit].T).predict(


### PR DESCRIPTION
The normalize option no longer exists in newest scikit-learn versions, breaking preprocessing functionality for these versions.
To maintain functionality, we use a pipeline with standard scaler.